### PR TITLE
Fix some typos in comments and documentation

### DIFF
--- a/doc/image-processing.md
+++ b/doc/image-processing.md
@@ -64,7 +64,7 @@ The **grayfilter** removes areas which are gray-only, that means it
 wipes out all those areas which do not contain a maximum relative
 amount of non-dark pixels. The size of the local area the *grayfilter*
 operates on can be set using `--grayfilter-size`, and the granularity
-of detection is controlled via `--grayfiter-step`.  The maximum
+of detection is controlled via `--grayfilter-step`.  The maximum
 relative amount of non-dark pixels that are still considered to be
 deletable can be set using `--grayfilter-threshold`.
 

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -68,7 +68,7 @@ static bool masksOverlapAny(int m[EDGES_COUNT], int masks[MAX_MASKS][EDGES_COUNT
 /**
  * Returns the maximum peak value that occurs when shifting a rotated virtual line above the image,
  * starting from one edge of an area and moving towards the middle point of the area.
- * The peak value is calulated by the absolute difference in the average blackness of pixels that occurs between two single shifting steps.
+ * The peak value is calculated by the absolute difference in the average blackness of pixels that occurs between two single shifting steps.
  *
  * @param m ascending slope of the virtually shifted (m=tan(angle)). Mind that this is negative for negative radians.
  */

--- a/parse.c
+++ b/parse.c
@@ -177,7 +177,7 @@ void printEdges(int d) {
 
 
 /**
- * Parses either a single integer string, of a pair of two integers seperated
+ * Parses either a single integer string, of a pair of two integers separated
  * by a comma.
  */
 void parseInts(char* s, int i[2]) {
@@ -260,7 +260,7 @@ int parseColor(char* s) {
 
 
 /**
- * Parses either a single float string, of a pair of two floats seperated
+ * Parses either a single float string, of a pair of two floats separated
  * by a comma.
  */
 void parseFloats(char* s, float f[2]) {

--- a/tests/runtestE1.sh
+++ b/tests/runtestE1.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo "[E1] Splitting 2-page layout into seperate output pages (with input and output wildcard)."
+echo "[E1] Splitting 2-page layout into separate output pages (with input and output wildcard)."
 
 set -e
 set -x

--- a/tests/runtestE2.sh
+++ b/tests/runtestE2.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo "[E2] Splitting 2-page layout into seperate output pages (with output wildcard only)."
+echo "[E2] Splitting 2-page layout into separate output pages (with output wildcard only)."
 
 set -e
 set -x

--- a/tests/runtestE3.sh
+++ b/tests/runtestE3.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo "[E3] Splitting 2-page layout into seperate output pages (with explicit input and output)."
+echo "[E3] Splitting 2-page layout into separate output pages (with explicit input and output)."
 
 set -e
 set -x


### PR DESCRIPTION
Most of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>